### PR TITLE
Blade component

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ imgix('astrotomic')->createURL('logo.png');
 There is a Blade component `x-imgix` included in this package:
 
 ```html
-<x-imgix path="my-image.png" />
+<x-imgix path="my-image.png" class="img-class" alt="My fancy image"/>
 ```
 
-**Optinal parameters:**
+**Optional parameters:**
 
 * `source`: use one of the source defined in your `imgix.php` config
 * `width`: define the output width

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Imgix::source('astrotomic')->createURL('logo.png');
 // https://img.astrotomic.info/logo.png?s=200c1c2065023265285dcbc4eff99955
 ```
 
-If you don't want to import the facade, for example in Blade views, you can use the global function which is an alias to the `Imgix::source()` method.
+If you don't want to import the facade, you can use the global function which is an alias to the `Imgix::source()` method.
 
 ```php
 imgix()->createURL('my/cool/image.jpg');
@@ -77,6 +77,20 @@ imgix()->createURL('my/cool/image.jpg');
 imgix('astrotomic')->createURL('logo.png');
 // https://img.astrotomic.info/logo.png?s=200c1c2065023265285dcbc4eff99955
 ```
+
+### Blade component 
+
+There is a Blade component `x-imgix` included in this package:
+
+```html
+<x-imgix path="my-image.png" />
+```
+
+**Optinal parameters:**
+
+* `source`: use one of the source defined in your `imgix.php` config
+* `width`: define the output width
+* `height`: define the output height
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ There is a Blade component `x-imgix` included in this package:
 * `width`: define the output width
 * `height`: define the output height
 
+You can publish the view by running
+`php artisan vendor:publish --provider="Astrotomic\Imgix\ImgixServiceProvider" --tag="views".
+
 ## Testing
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0",
         "imgix/imgix-php": "^3.3"
     },

--- a/resources/views/components/imgix.blade.php
+++ b/resources/views/components/imgix.blade.php
@@ -6,5 +6,6 @@
         @if($width) width="{{ $width }}" @endif
         @if($height) height="{{ $height }}" @endif
         loading="lazy"
+        {{ $attributes }}
     />
 </picture>

--- a/resources/views/components/imgix.blade.php
+++ b/resources/views/components/imgix.blade.php
@@ -6,6 +6,5 @@
         @if($width) width="{{ $width }}" @endif
         @if($height) height="{{ $height }}" @endif
         loading="lazy"
-        {{ $attributes }}
     />
 </picture>

--- a/resources/views/components/imgix.blade.php
+++ b/resources/views/components/imgix.blade.php
@@ -1,0 +1,11 @@
+<picture>
+    <source type="image/webp" srcset="{{ $srcSet('webp') }}"/>
+    <img
+        src="{{ $src() }}"
+        srcset="{{ $srcSet() }}"
+        @if($width) width="{{ $width }}" @endif
+        @if($height) height="{{ $height }}" @endif
+        loading="lazy"
+        {{ $attributes }}
+    />
+</picture>

--- a/src/ImgixServiceProvider.php
+++ b/src/ImgixServiceProvider.php
@@ -18,6 +18,10 @@ class ImgixServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(__DIR__ . '/../resources/views', 'imgix');
 
+        $this->publishes([
+            __DIR__.'/../resources/views' => resource_path('views/vendor/astrotomic/laravel-imgix'),
+        ], 'views');
+
         Blade::component('imgix', Imgix::class);
     }
 

--- a/src/ImgixServiceProvider.php
+++ b/src/ImgixServiceProvider.php
@@ -2,7 +2,9 @@
 
 namespace Astrotomic\Imgix;
 
+use Astrotomic\Imgix\View\Components\Imgix;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use Imgix\UrlBuilder;
 
@@ -13,6 +15,10 @@ class ImgixServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../config/imgix.php' => config_path('imgix.php'),
         ], 'config');
+
+        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'imgix');
+
+        Blade::component('imgix', Imgix::class);
     }
 
     public function register(): void

--- a/src/View/Components/Imgix.php
+++ b/src/View/Components/Imgix.php
@@ -44,11 +44,13 @@ class Imgix extends Component
         return $this->imgixManager->source($this->source)->createURL($this->path, $params);
     }
 
-    public function srcSet(string $format = 'webp'): string
+    public function srcSet(?string $format = null): string
     {
-        $params = [
-            'fm' => $format,
-        ];
+        $params = [];
+
+        if($format) {
+            $params['fm'] = $format;
+        }
 
         if($this->imgHeight) {
             $params['h'] = $this->imgHeight;

--- a/src/View/Components/Imgix.php
+++ b/src/View/Components/Imgix.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Astrotomic\Imgix\View\Components;
+
+use Astrotomic\Imgix\ImgixManager;
+use Illuminate\View\Component;
+
+class Imgix extends Component
+{
+    protected ImgixManager $imgixManager;
+    protected string $path;
+
+    protected ?string $source;
+    protected ?string $imgWidth;
+    protected ?string $imgHeight;
+
+    public function __construct(
+        ImgixManager $imgixManager,
+        string $path,
+        ?string $source = null,
+        ?string $width = null,
+        ?string $height = null
+    )
+    {
+        $this->imgixManager = $imgixManager;
+        $this->path = $path;
+        $this->source = $source;
+        $this->imgWidth = $width;
+        $this->imgHeight = $height;
+    }
+
+    public function src(): string
+    {
+        return $this->imgixManager->source($this->source)->createURL($this->path);
+    }
+
+    public function srcSet(string $format = 'webp'): string
+    {
+        return $this->imgixManager->source($this->source)->createSrcSet($this->path, [
+            'fm' => $format,
+        ]);
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|string
+     */
+    public function render()
+    {
+        return view('imgix::components.imgix', [
+            'width' => $this->imgWidth,
+            'height' => $this->imgHeight,
+        ]);
+    }
+}

--- a/src/View/Components/Imgix.php
+++ b/src/View/Components/Imgix.php
@@ -31,14 +31,34 @@ class Imgix extends Component
 
     public function src(): string
     {
-        return $this->imgixManager->source($this->source)->createURL($this->path);
+        $params = [];
+
+        if($this->imgHeight) {
+            $params['h'] = $this->imgHeight;
+        }
+
+        if($this->imgWidth) {
+            $params['w'] = $this->imgWidth;
+        }
+
+        return $this->imgixManager->source($this->source)->createURL($this->path, $params);
     }
 
     public function srcSet(string $format = 'webp'): string
     {
-        return $this->imgixManager->source($this->source)->createSrcSet($this->path, [
+        $params = [
             'fm' => $format,
-        ]);
+        ];
+
+        if($this->imgHeight) {
+            $params['h'] = $this->imgHeight;
+        }
+
+        if($this->imgWidth) {
+            $params['w'] = $this->imgWidth;
+        }
+
+        return $this->imgixManager->source($this->source)->createSrcSet($this->path, $params);
     }
 
     /**

--- a/src/View/Components/Imgix.php
+++ b/src/View/Components/Imgix.php
@@ -11,15 +11,15 @@ class Imgix extends Component
     protected string $path;
 
     protected ?string $source;
-    protected ?string $imgWidth;
-    protected ?string $imgHeight;
+    protected ?int $imgWidth;
+    protected ?int $imgHeight;
 
     public function __construct(
         ImgixManager $imgixManager,
         string $path,
         ?string $source = null,
-        ?string $width = null,
-        ?string $height = null
+        ?int $width = null,
+        ?int $height = null
     )
     {
         $this->imgixManager = $imgixManager;

--- a/src/View/Components/Imgix.php
+++ b/src/View/Components/Imgix.php
@@ -13,13 +13,15 @@ class Imgix extends Component
     protected ?string $source;
     protected ?int $imgWidth;
     protected ?int $imgHeight;
+    protected ?array $params;
 
     public function __construct(
         ImgixManager $imgixManager,
         string $path,
         ?string $source = null,
         ?int $width = null,
-        ?int $height = null
+        ?int $height = null,
+        ?array $params = null
     )
     {
         $this->imgixManager = $imgixManager;
@@ -27,6 +29,7 @@ class Imgix extends Component
         $this->source = $source;
         $this->imgWidth = $width;
         $this->imgHeight = $height;
+        $this->params = $params;
     }
 
     public function src(): string
@@ -39,6 +42,10 @@ class Imgix extends Component
 
         if($this->imgWidth) {
             $params['w'] = $this->imgWidth;
+        }
+
+        if($this->params) {
+            $params = $params + $this->params;
         }
 
         return $this->imgixManager->source($this->source)->createURL($this->path, $params);
@@ -58,6 +65,10 @@ class Imgix extends Component
 
         if($this->imgWidth) {
             $params['w'] = $this->imgWidth;
+        }
+
+        if($this->params) {
+            $params = $params + $this->params;
         }
 
         return $this->imgixManager->source($this->source)->createSrcSet($this->path, $params);

--- a/tests/ImgixViewComponentTest.php
+++ b/tests/ImgixViewComponentTest.php
@@ -32,10 +32,11 @@ class ImgixViewComponentTest extends TestCase
     {
         $component = new Imgix(resolve(ImgixManager::class), 'my-demo-image.png');
 
-        $this->assertStringContainsString('webp', $component->srcSet());
-        $this->assertStringContainsString('png', $component->srcSet('png'));
-        $this->assertStringContainsString('jpg', $component->srcSet('jpg'));
-        $this->assertStringContainsString('jm2', $component->srcSet('jm2'));
+        $this->assertStringNotContainsString('fm=', $component->srcSet());
+        $this->assertStringContainsString('fm=webp', $component->srcSet('webp'));
+        $this->assertStringContainsString('fm=png', $component->srcSet('png'));
+        $this->assertStringContainsString('fm=jpg', $component->srcSet('jpg'));
+        $this->assertStringContainsString('fm=jm2', $component->srcSet('jm2'));
     }
 
     /** @test  */

--- a/tests/ImgixViewComponentTest.php
+++ b/tests/ImgixViewComponentTest.php
@@ -37,4 +37,17 @@ class ImgixViewComponentTest extends TestCase
         $this->assertStringContainsString('jpg', $component->srcSet('jpg'));
         $this->assertStringContainsString('jm2', $component->srcSet('jm2'));
     }
+
+    /** @test  */
+    public function it_can_set_width_and_height(): void
+    {
+        $component = new Imgix(
+            resolve(ImgixManager::class), 'my-demo-image.png', 'default', '640', '480'
+        );
+
+        $this->assertStringContainsString('w=640', $component->src());
+        $this->assertStringContainsString('h=480', $component->src());
+        $this->assertStringContainsString('w=640', $component->srcSet());
+        $this->assertStringContainsString('h=480', $component->srcSet());
+    }
 }

--- a/tests/ImgixViewComponentTest.php
+++ b/tests/ImgixViewComponentTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Astrotomic\Imgix\Tests;
+
+use Astrotomic\Imgix\ImgixManager;
+use Astrotomic\Imgix\View\Components\Imgix;
+
+class ImgixViewComponentTest extends TestCase
+{
+    /** @test  */
+    public function it_can_get_src_with_default_source(): void
+    {
+        $component = new Imgix(resolve(ImgixManager::class), 'my-demo-image.png');
+
+        $this->assertTrue((bool) strpos($component->src(), config('imgix.sources.default.domain')));
+        $this->assertTrue((bool) filter_var($component->src(), FILTER_VALIDATE_URL));
+    }
+
+    /** @test  */
+    public function it_can_get_src_with_custom_source(): void
+    {
+        $component = new Imgix(resolve(ImgixManager::class), 'my-demo-image.png', 'astrotomic');
+
+        $this->assertStringContainsString(config('imgix.sources.astrotomic.domain'), $component->src());
+        $this->assertTrue((bool) filter_var($component->src(), FILTER_VALIDATE_URL));
+    }
+
+    /** @test  */
+    public function it_can_get_srcset_with_different_formats(): void
+    {
+        $component = new Imgix(resolve(ImgixManager::class), 'my-demo-image.png');
+
+        $this->assertStringContainsString('webp', $component->srcSet());
+        $this->assertStringContainsString('png', $component->srcSet('png'));
+        $this->assertStringContainsString('jpg', $component->srcSet('jpg'));
+        $this->assertStringContainsString('jm2', $component->srcSet('jm2'));
+    }
+}

--- a/tests/ImgixViewComponentTest.php
+++ b/tests/ImgixViewComponentTest.php
@@ -51,4 +51,33 @@ class ImgixViewComponentTest extends TestCase
         $this->assertStringContainsString('w=640', $component->srcSet());
         $this->assertStringContainsString('h=480', $component->srcSet());
     }
+
+    /** @test  */
+    public function it_can_handle_params(): void
+    {
+        $params = [
+            'crop' => 'edges',
+            'fit' => 'crop',
+        ];
+
+        $component = new Imgix(
+            resolve(ImgixManager::class), 'my-demo-image.png', 'default', 640, 480, $params
+        );
+
+        $this->assertStringContainsString('fit=crop', $component->src());
+        $this->assertStringContainsString('crop=edges', $component->src());
+        $this->assertStringContainsString('fit=crop', $component->srcSet());
+        $this->assertStringContainsString('crop=edges', $component->srcSet());
+
+        $params = [];
+
+        $component = new Imgix(
+            resolve(ImgixManager::class), 'my-demo-image.png', 'default', 640, 480, $params
+        );
+
+        $this->assertStringNotContainsString('fit=crop', $component->src());
+        $this->assertStringNotContainsString('crop=edges', $component->src());
+        $this->assertStringNotContainsString('fit=crop', $component->srcSet());
+        $this->assertStringNotContainsString('crop=edges', $component->srcSet());
+    }
 }

--- a/tests/ImgixViewComponentTest.php
+++ b/tests/ImgixViewComponentTest.php
@@ -42,7 +42,7 @@ class ImgixViewComponentTest extends TestCase
     public function it_can_set_width_and_height(): void
     {
         $component = new Imgix(
-            resolve(ImgixManager::class), 'my-demo-image.png', 'default', '640', '480'
+            resolve(ImgixManager::class), 'my-demo-image.png', 'default', 640, 480
         );
 
         $this->assertStringContainsString('w=640', $component->src());


### PR DESCRIPTION
#1 

This blade component `x-imgix` with this signature:

```
<x-imgix path="my-image.png" width="640" height="480" source="astrotomic" />
```

As described in the issue #1 only the `path` attribute is mandatory.

⚠️ This PR sets the minimum version of PHP to `7.4`. 